### PR TITLE
Add PyPI publish workflow and release script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build
+        run: python -m build
+
+      - name: Check
+        run: twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mattstash"
-version = "0.1.2"
+version = "0.1.4"
 description = "Tiny KeePass-powered secrets accessor with optional S3 helper and Postgres URL builder."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }

--- a/scripts/update-pypi.sh
+++ b/scripts/update-pypi.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+# MattStash PyPI publish script
+# Usage: ./scripts/update-pypi.sh [--test]
+#
+# Options:
+#   --test    Upload to TestPyPI instead of PyPI
+#
+# Prerequisites:
+#   pip install build twine
+#
+# Authentication:
+#   Set TWINE_USERNAME=__token__ and TWINE_PASSWORD=<your-pypi-api-token>
+#   Or configure ~/.pypirc
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# Parse args
+REPO_FLAG=""
+if [[ "${1:-}" == "--test" ]]; then
+    REPO_FLAG="--repository testpypi"
+    echo "==> Uploading to TestPyPI"
+else
+    echo "==> Uploading to PyPI"
+fi
+
+# Extract version from pyproject.toml
+VERSION=$(python -c "
+import re
+with open('pyproject.toml') as f:
+    m = re.search(r'version\s*=\s*\"([^\"]+)\"', f.read())
+    print(m.group(1) if m else 'unknown')
+")
+echo "==> Version: $VERSION"
+
+# Preflight checks
+echo "==> Running tests..."
+python -m pytest tests/ --ignore=tests/integration -q || {
+    echo "ERROR: Tests failed. Aborting release."
+    exit 1
+}
+
+echo "==> Running mypy..."
+python -m mypy src/mattstash/ --strict || {
+    echo "ERROR: Type checking failed. Aborting release."
+    exit 1
+}
+
+# Clean previous builds
+echo "==> Cleaning old artifacts..."
+rm -rf dist/ build/ src/*.egg-info
+
+# Build sdist + wheel
+echo "==> Building..."
+python -m build
+
+# Verify the built artifacts
+echo "==> Verifying..."
+twine check dist/*
+
+# Confirm
+echo ""
+echo "Ready to upload mattstash $VERSION"
+read -r -p "Continue? [y/N] " confirm
+if [[ "$confirm" != [yY] ]]; then
+    echo "Aborted."
+    exit 0
+fi
+
+# Upload
+echo "==> Uploading..."
+twine upload $REPO_FLAG dist/*
+
+echo "==> Done! mattstash $VERSION published."
+echo "    https://pypi.org/project/mattstash/$VERSION/"


### PR DESCRIPTION
Add a GitHub Actions workflow (.github/workflows/publish.yml) that builds and publishes the package on tag pushes (v*) using Python 3.12 and pypa/gh-action-pypi-publish with PYPI_API_TOKEN. Bump project version in pyproject.toml to 0.1.4. Add an executable scripts/update-pypi.sh helper to run tests, mypy, build artifacts, check with twine, and upload to PyPI or TestPyPI (supports --test), with interactive confirmation and basic preflight checks.