### PR TITLE
Bump version to 0.1.7 and set PyPI env

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,6 +100,13 @@ cd server && source venv/bin/activate
 
 ### Development Scripts
 
+#### `scripts/lint.sh` - Linting
+Runs ruff check and format verification. Use `--fix` to auto-fix issues. **Always run this before committing.**
+```bash
+./scripts/lint.sh          # Check only
+./scripts/lint.sh --fix    # Auto-fix
+```
+
 #### `scripts/run-tests.sh` - Test Suite
 Runs the full test suite with pytest.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
   release:
     needs: [ci]
     runs-on: ubuntu-latest
+    environment: pypi
     # Skip if the commit was made by the release bot (prevents infinite loop)
     if: "!contains(github.event.head_commit.message, '[skip-release]')"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mattstash"
-version = "0.1.4"
+version = "0.1.7"
 description = "Tiny KeePass-powered secrets accessor with optional S3 helper and Postgres URL builder."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Run linting checks for MattStash
+#
+# Usage: ./scripts/lint.sh [OPTIONS]
+#   --fix    Auto-fix fixable issues
+#
+# Examples:
+#   ./scripts/lint.sh          # Check only (CI-safe)
+#   ./scripts/lint.sh --fix    # Check and auto-fix
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+FIX_FLAG=""
+if [ "$1" = "--fix" ]; then
+    FIX_FLAG="--fix"
+    echo "=== Ruff check (with auto-fix) ==="
+else
+    echo "=== Ruff check ==="
+fi
+
+ruff check $FIX_FLAG src/ tests/
+
+echo ""
+echo "=== Ruff format check ==="
+if [ "$1" = "--fix" ]; then
+    ruff format src/ tests/
+else
+    ruff format --check src/ tests/
+fi
+
+echo ""
+echo "All lint checks passed."

--- a/src/mattstash/__init__.py
+++ b/src/mattstash/__init__.py
@@ -5,6 +5,8 @@ MattStash: KeePass-backed secrets management
 A simple, credstash-like interface to KeePass databases.
 """
 
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
 # Import from the new refactored structure
 # Import CLI entry point
 from .cli.main import main as cli_main
@@ -28,7 +30,10 @@ DEFAULT_KDBX_PATH = config.default_db_path
 DEFAULT_KDBX_SIDECAR_BASENAME = config.sidecar_basename
 PAD_WIDTH = config.version_pad_width
 
-__version__ = "0.1.2"
+try:
+    __version__: str = _pkg_version("mattstash")
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # fallback for editable / uninstalled
 
 __all__ = [
     # Constants

--- a/src/mattstash/__init__.py
+++ b/src/mattstash/__init__.py
@@ -5,7 +5,8 @@ MattStash: KeePass-backed secrets management
 A simple, credstash-like interface to KeePass databases.
 """
 
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 # Import from the new refactored structure
 # Import CLI entry point


### PR DESCRIPTION
Update release workflow to use the 'pypi' environment for the release job, bump the project version in pyproject.toml from 0.1.4 to 0.1.7, and make the package __version__ resolve dynamically at runtime using importlib.metadata.version with a PackageNotFoundError fallback (useful for editable/uninstalled development). Files changed: .github/workflows/release.yml, pyproject.toml, src/mattstash/__init__.py.