### PR TITLE
test: add integration tests for Docker server gaps

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("mattstash.api")
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):  # pragma: no cover
+async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     # Startup
     logger.info("Starting %s", config.API_TITLE)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -253,6 +253,36 @@ def reset_config_cache():
 
 
 @pytest.fixture
+def real_db_mattstash(tmp_path) -> MattStash:
+    """MattStash instance backed by a real temporary KeePass database."""
+    from pykeepass import create_database
+
+    db_path = tmp_path / "roundtrip.kdbx"
+    password = "test-roundtrip-pass"
+    create_database(str(db_path), password=password)
+    # DB already exists so bootstrap_if_missing is a no-op
+    return MattStash(path=str(db_path), password=password)
+
+
+@pytest.fixture
+def real_kdbx_client(test_app, real_db_mattstash):
+    """TestClient wired to a real KeePass database (no mocks in the data layer)."""
+    from app.dependencies import get_mattstash, verify_api_key_header
+    from fastapi.testclient import TestClient
+
+    ms = real_db_mattstash
+    test_app.dependency_overrides[get_mattstash] = lambda: ms
+    # Override auth so api_keys.py's stale module-level config reference doesn't
+    # interfere; auth is tested separately in test_api_keys.py.
+    test_app.dependency_overrides[verify_api_key_header] = lambda: "test-api-key"
+
+    client = TestClient(test_app)
+    yield client
+
+    test_app.dependency_overrides.clear()
+
+
+@pytest.fixture
 def test_client_factory(monkeypatch):
     """Factory to create TestClient with custom config."""
     def _create_client(mock_mattstash_instance=None, api_keys=None):

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -163,3 +163,18 @@ class TestConfig:
         config = config_module.Config()
         with pytest.raises(ValueError, match="At least one API key must be provided"):
             config.get_api_keys()
+
+    def test_get_kdbx_password_file_strips_whitespace(self, tmp_path, monkeypatch, clean_env):
+        """KDBX_PASSWORD_FILE content is stripped of surrounding whitespace."""
+        password_file = tmp_path / "password.txt"
+        password_file.write_text("  mypassword  \n")
+
+        from importlib import reload
+        import app.config as config_module
+        reload(config_module)
+
+        monkeypatch.setattr(config_module.Config, "KDBX_PASSWORD", None)
+        monkeypatch.setattr(config_module.Config, "KDBX_PASSWORD_FILE", str(password_file))
+
+        config = config_module.Config()
+        assert config.get_kdbx_password() == "mypassword"

--- a/server/tests/test_lifespan.py
+++ b/server/tests/test_lifespan.py
@@ -1,0 +1,45 @@
+"""Tests for application lifespan startup validation."""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import Config
+from app.main import create_app
+
+
+def test_startup_fails_no_kdbx_password(monkeypatch):
+    """Lifespan raises ValueError when no KDBX password is configured."""
+    monkeypatch.setattr(Config, "KDBX_PASSWORD", None)
+    monkeypatch.setattr(Config, "KDBX_PASSWORD_FILE", None)
+    monkeypatch.setattr(Config, "API_KEY", "test-key")
+    monkeypatch.setattr(Config, "API_KEYS_FILE", None)
+
+    application = create_app()
+    with pytest.raises(ValueError, match="KDBX password must be provided"):
+        with TestClient(application):
+            pass  # pragma: no cover
+
+
+def test_startup_fails_kdbx_password_file_not_found(monkeypatch):
+    """Lifespan raises FileNotFoundError when KDBX_PASSWORD_FILE path does not exist."""
+    monkeypatch.setattr(Config, "KDBX_PASSWORD", None)
+    monkeypatch.setattr(Config, "KDBX_PASSWORD_FILE", "/nonexistent/path.txt")
+    monkeypatch.setattr(Config, "API_KEY", "test-key")
+    monkeypatch.setattr(Config, "API_KEYS_FILE", None)
+
+    application = create_app()
+    with pytest.raises(FileNotFoundError, match="Password file not found"):
+        with TestClient(application):
+            pass  # pragma: no cover
+
+
+def test_startup_fails_no_api_keys(monkeypatch):
+    """Lifespan raises ValueError when no API keys are configured."""
+    monkeypatch.setattr(Config, "KDBX_PASSWORD", "testpass")
+    monkeypatch.setattr(Config, "KDBX_PASSWORD_FILE", None)
+    monkeypatch.setattr(Config, "API_KEY", None)
+    monkeypatch.setattr(Config, "API_KEYS_FILE", None)
+
+    application = create_app()
+    with pytest.raises(ValueError, match="At least one API key must be provided"):
+        with TestClient(application):
+            pass  # pragma: no cover

--- a/server/tests/test_router_credentials_roundtrip.py
+++ b/server/tests/test_router_credentials_roundtrip.py
@@ -1,0 +1,45 @@
+"""Full HTTP round-trip integration tests: POST → GET → DELETE."""
+
+_API_KEY = "test-api-key"
+_HEADERS = {"X-API-Key": _API_KEY}
+_CRED_NAME = "roundtrip-cred"
+
+
+def test_post_get_delete_roundtrip(real_kdbx_client):
+    """POST a credential, GET it back, then DELETE it — verifying end-to-end HTTP flow."""
+    client = real_kdbx_client
+
+    # --- POST: create ---
+    response = client.post(
+        f"/api/v1/credentials/{_CRED_NAME}",
+        json={"value": "my-secret-value"},
+        headers=_HEADERS,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == _CRED_NAME
+    assert data["created"] is True
+
+    # --- GET: read back with password revealed ---
+    response = client.get(
+        f"/api/v1/credentials/{_CRED_NAME}?show_password=true",
+        headers=_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == _CRED_NAME
+    assert data["password"] == "my-secret-value"
+
+    # --- DELETE: remove ---
+    response = client.delete(
+        f"/api/v1/credentials/{_CRED_NAME}",
+        headers=_HEADERS,
+    )
+    assert response.status_code == 200
+
+    # Verify deletion: GET should now return 404
+    response = client.get(
+        f"/api/v1/credentials/{_CRED_NAME}",
+        headers=_HEADERS,
+    )
+    assert response.status_code == 404

--- a/tests/integration/test_cli_workflows.py
+++ b/tests/integration/test_cli_workflows.py
@@ -394,3 +394,14 @@ class TestCLICompleteWorkflow:
         # Verify deletion
         result = run_cli(["get", "workflow-test", "--db", str(db_path)])
         assert result.returncode != 0
+
+
+class TestCLIServerShim:
+    """Test the informational 'server' subcommand."""
+
+    def test_server_command_shows_docker_run(self):
+        """mattstash server exits 0 and prints docker run instructions."""
+        result = run_cli(["server"])
+
+        assert result.returncode == 0
+        assert "docker run" in result.stdout


### PR DESCRIPTION
## Summary

Closes the four integration-test gaps identified in the review.

### Area 1 — Lifespan startup failures
Removes \`# pragma: no cover\` from \`lifespan()\` and adds \`server/tests/test_lifespan.py\` with three tests that call \`create_app()\`, enter the TestClient context, and assert the correct exception is raised during startup:
- \`ValueError\` when both \`KDBX_PASSWORD\` and \`KDBX_PASSWORD_FILE\` are unset
- \`FileNotFoundError\` when \`KDBX_PASSWORD_FILE\` points to a nonexistent path
- \`ValueError\` when no API keys are configured

### Area 2 — Full HTTP POST → GET → DELETE round-trip
Adds two fixtures to \`server/tests/conftest.py\`:
- \`real_db_mattstash\` — creates a temporary KeePass database via \`pykeepass.create_database()\` and returns a live \`MattStash\` instance
- \`real_kdbx_client\` — wires that instance into the \`test_app\` via dependency override (no data-layer mocks)

Adds \`server/tests/test_router_credentials_roundtrip.py\` with a single end-to-end test: POST → assert 201, GET → assert 200 + password present, DELETE → assert 200, GET again → assert 404.

### Area 3 — CLI \`server\` shim
Adds \`TestCLIServerShim.test_server_command_shows_docker_run\` to \`tests/integration/test_cli_workflows.py\`. The command already existed inline in \`src/mattstash/cli/main.py\`; the test asserts \`returncode == 0\` and \`"docker run" in stdout\`.

### Area 4 — \`KDBX_PASSWORD_FILE\` whitespace edge case
Adds \`test_get_kdbx_password_file_strips_whitespace\` to \`server/tests/test_config.py\`. Writes \`"  mypassword  \n"\` to a \`tmp_path\` file and asserts \`.strip()\` is applied (\`"mypassword"\` returned), covering a branch not exercised by the existing conftest fixture.