### PR TITLE
fix: use correct kwarg \`path=\` in get_mattstash() MattStash constructor

### DIFF
--- a/server/app/dependencies.py
+++ b/server/app/dependencies.py
@@ -27,7 +27,7 @@ def get_mattstash() -> MattStash:  # pragma: no cover
                 try:
                     password = config.get_kdbx_password()
                     _mattstash_instance = MattStash(
-                        db_path=config.DB_PATH,
+                        path=config.DB_PATH,
                         password=password
                     )
                 except Exception as e:

--- a/server/tests/test_dependencies.py
+++ b/server/tests/test_dependencies.py
@@ -1,0 +1,32 @@
+"""Tests for app.dependencies — get_mattstash() integration."""
+import threading
+
+import pytest
+from pykeepass import create_database
+
+from app.config import Config
+from app.dependencies import _mattstash_lock, get_mattstash
+
+
+def test_get_mattstash_constructs_with_real_kdbx(tmp_path, monkeypatch):
+    """get_mattstash() must pass `path=` (not `db_path=`) to MattStash().
+
+    Regression test for the db_path→path kwarg bug that caused a TypeError
+    and silent 503 on every credential endpoint.
+    """
+    db_file = tmp_path / "test.kdbx"
+    password = "regression-test-pw"
+    create_database(str(db_file), password=password)
+
+    monkeypatch.setattr(Config, "DB_PATH", str(db_file))
+    monkeypatch.setattr(Config, "KDBX_PASSWORD", password)
+    monkeypatch.setattr(Config, "KDBX_PASSWORD_FILE", None)
+
+    # Reset the cached singleton so get_mattstash() creates a fresh instance
+    import app.dependencies as deps
+    deps._mattstash_instance = None
+
+    instance = get_mattstash()
+
+    assert instance is not None
+    assert instance.path == str(db_file)


### PR DESCRIPTION
## Bug

\`server/app/dependencies.py\` passed \`db_path=config.DB_PATH\` to \`MattStash()\`, but the constructor signature is \`__init__(self, path=None, password=None)\`. Python raised \`TypeError: MattStash.__init__() got an unexpected keyword argument 'db_path'\`, which \`get_mattstash()\` caught and converted to an HTTP 503 — silently breaking every credential endpoint.

## Fix

One-character change: \`db_path=\` → \`path=\`.

## Regression test

New \`server/tests/test_dependencies.py\` creates a real temporary kdbx via \`pykeepass.create_database()\`, monkeypatches \`Config.DB_PATH\` and \`Config.KDBX_PASSWORD\`, and calls \`get_mattstash()\` — asserting the instance is created successfully and \`instance.path\` matches the expected file.