### PR TITLE
feat: auto-reload KDBX on external modifications

### DIFF
--- a/server/app/config.py
+++ b/server/app/config.py
@@ -24,6 +24,9 @@ class Config:
     # Rate limiting
     RATE_LIMIT: str = os.getenv("MATTSTASH_RATE_LIMIT", "100/minute")
     
+    # Database file change polling
+    DB_POLL_INTERVAL: int = int(os.getenv("MATTSTASH_DB_POLL_INTERVAL", "5"))
+    
     # API metadata
     API_VERSION: str = "v1"
     API_TITLE: str = "MattStash API"

--- a/server/app/dependencies.py
+++ b/server/app/dependencies.py
@@ -43,6 +43,34 @@ def get_mattstash() -> MattStash:  # pragma: no cover
     return _mattstash_instance
 
 
+def reload_mattstash() -> bool:
+    """Force the singleton MattStash instance to reload from disk.
+
+    Returns:
+        True if reload was successful, False otherwise.
+    """
+    global _mattstash_instance
+
+    with _mattstash_lock:
+        if _mattstash_instance is None:
+            return False
+        return _mattstash_instance.reload()
+
+
+def reload_mattstash_if_changed() -> bool:
+    """Check for external KDBX modifications and reload if detected.
+
+    Returns:
+        True if a reload was performed, False otherwise.
+    """
+    global _mattstash_instance
+
+    with _mattstash_lock:
+        if _mattstash_instance is None:
+            return False
+        return _mattstash_instance.reload_if_changed()
+
+
 async def verify_api_key_header(  # pragma: no cover
     x_api_key: Annotated[str | None, Header()] = None
 ) -> str:

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,4 +1,5 @@
 """FastAPI application factory and main entry point."""
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 
@@ -8,11 +9,29 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
 from .config import config
+from .dependencies import reload_mattstash_if_changed
 from .middleware.logging import RequestLoggingMiddleware
 from .rate_limit import limiter
-from .routers import credentials, db_url, health
+from .routers import admin, credentials, db_url, health
 
 logger = logging.getLogger("mattstash.api")
+
+
+async def _poll_database_changes() -> None:
+    """Background task that periodically checks for external KDBX changes."""
+    interval = config.DB_POLL_INTERVAL
+    if interval <= 0:
+        logger.info("Database change polling disabled (interval=%d)", interval)
+        return
+
+    logger.info("Database change polling started (every %ds)", interval)
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            if reload_mattstash_if_changed():
+                logger.info("Database auto-reloaded after external modification")
+        except Exception:
+            logger.exception("Error during database change poll")
 
 
 @asynccontextmanager
@@ -33,9 +52,17 @@ async def lifespan(app: FastAPI):
         )
         raise
 
+    # Start background poller for external DB modifications
+    poller_task = asyncio.create_task(_poll_database_changes())
+
     yield
 
     # Shutdown
+    poller_task.cancel()
+    try:
+        await poller_task
+    except asyncio.CancelledError:
+        pass
     logger.info("Shutting down MattStash API")
 
 
@@ -78,6 +105,11 @@ def create_app() -> FastAPI:
         db_url.router,
         prefix=f"/api/{config.API_VERSION}",
         tags=["database"]
+    )
+    app.include_router(
+        admin.router,
+        prefix=f"/api/{config.API_VERSION}",
+        tags=["admin"]
     )
 
     return app

--- a/server/app/routers/__init__.py
+++ b/server/app/routers/__init__.py
@@ -1,4 +1,4 @@
 """Routers package initialization."""
-from . import credentials, db_url, health
+from . import admin, credentials, db_url, health
 
-__all__ = ["health", "credentials", "db_url"]
+__all__ = ["health", "credentials", "db_url", "admin"]

--- a/server/app/routers/admin.py
+++ b/server/app/routers/admin.py
@@ -1,0 +1,31 @@
+"""Admin router for operational endpoints."""
+import logging
+
+from fastapi import APIRouter, Request
+
+from ..dependencies import APIKeyDep, reload_mattstash
+from ..rate_limit import limiter
+
+logger = logging.getLogger("mattstash.api")
+router = APIRouter()
+
+
+@router.post("/admin/reload")
+@limiter.limit("10/minute")
+async def force_reload(  # pragma: no cover
+    request: Request,
+    api_key: APIKeyDep,
+) -> dict[str, str]:
+    """
+    Force the server to reload the KeePass database from disk.
+
+    Useful after external modifications (e.g., via the CLI).
+    """
+    success = reload_mattstash()
+
+    if success:
+        logger.info("Database reloaded via admin endpoint")
+        return {"status": "reloaded"}
+    else:
+        logger.warning("Database reload requested but no instance to reload")
+        return {"status": "no_change"}

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -175,7 +175,7 @@ def test_app(clean_env, monkeypatch):
     from slowapi.util import get_remote_address
     from app.config import config
     from app.middleware.logging import RequestLoggingMiddleware
-    from app.routers import credentials, db_url, health
+    from app.routers import admin, credentials, db_url, health
     
     # Initialize rate limiter
     limiter = Limiter(key_func=get_remote_address, default_limits=[config.RATE_LIMIT])
@@ -209,6 +209,11 @@ def test_app(clean_env, monkeypatch):
         db_url.router,
         prefix=f"/api/{config.API_VERSION}",
         tags=["database"]
+    )
+    app.include_router(
+        admin.router,
+        prefix=f"/api/{config.API_VERSION}",
+        tags=["admin"]
     )
     
     return app

--- a/server/tests/test_router_admin.py
+++ b/server/tests/test_router_admin.py
@@ -1,0 +1,95 @@
+"""Tests for the admin reload endpoint."""
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+
+class TestAdminReloadEndpoint:
+    """Tests for POST /api/v1/admin/reload."""
+
+    def test_reload_success(self, test_app, mock_mattstash):
+        """Reload returns 200 with status 'reloaded' when successful."""
+        from app.dependencies import get_mattstash, verify_api_key_header
+
+        mock_mattstash.reload.return_value = True
+        test_app.dependency_overrides[get_mattstash] = lambda: mock_mattstash
+        test_app.dependency_overrides[verify_api_key_header] = lambda: "test-api-key"
+
+        with patch("app.routers.admin.reload_mattstash", return_value=True):
+            client = TestClient(test_app)
+            response = client.post(
+                "/api/v1/admin/reload",
+                headers={"X-API-Key": "test-api-key"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "reloaded"
+        test_app.dependency_overrides.clear()
+
+    def test_reload_no_instance(self, test_app):
+        """Reload returns 200 with status 'no_change' when no instance exists."""
+        from app.dependencies import verify_api_key_header
+
+        test_app.dependency_overrides[verify_api_key_header] = lambda: "test-api-key"
+
+        with patch("app.routers.admin.reload_mattstash", return_value=False):
+            client = TestClient(test_app)
+            response = client.post(
+                "/api/v1/admin/reload",
+                headers={"X-API-Key": "test-api-key"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "no_change"
+        test_app.dependency_overrides.clear()
+
+    def test_reload_requires_api_key(self, test_app):
+        """Reload endpoint requires authentication."""
+        client = TestClient(test_app)
+        response = client.post("/api/v1/admin/reload")
+
+        assert response.status_code == 401
+
+
+class TestReloadDependencyFunctions:
+    """Tests for reload_mattstash and reload_mattstash_if_changed in dependencies."""
+
+    def test_reload_mattstash_calls_instance_reload(self):
+        """reload_mattstash delegates to the singleton instance."""
+        import app.dependencies as deps
+
+        mock_instance = MagicMock()
+        mock_instance.reload.return_value = True
+        deps._mattstash_instance = mock_instance
+
+        result = deps.reload_mattstash()
+        assert result is True
+        mock_instance.reload.assert_called_once()
+
+    def test_reload_mattstash_no_instance(self):
+        """reload_mattstash returns False when no instance exists."""
+        import app.dependencies as deps
+
+        deps._mattstash_instance = None
+        result = deps.reload_mattstash()
+        assert result is False
+
+    def test_reload_if_changed_calls_instance(self):
+        """reload_mattstash_if_changed delegates to the singleton."""
+        import app.dependencies as deps
+
+        mock_instance = MagicMock()
+        mock_instance.reload_if_changed.return_value = True
+        deps._mattstash_instance = mock_instance
+
+        result = deps.reload_mattstash_if_changed()
+        assert result is True
+        mock_instance.reload_if_changed.assert_called_once()
+
+    def test_reload_if_changed_no_instance(self):
+        """reload_mattstash_if_changed returns False when no instance exists."""
+        import app.dependencies as deps
+
+        deps._mattstash_instance = None
+        result = deps.reload_mattstash_if_changed()
+        assert result is False

--- a/src/mattstash/core/entry_manager.py
+++ b/src/mattstash/core/entry_manager.py
@@ -22,9 +22,17 @@ logger = get_logger(__name__)
 class EntryManager:
     """Handles CRUD operations for KeePass entries."""
 
-    def __init__(self, kp: PyKeePass):
+    def __init__(self, kp: PyKeePass, save_callback=None):
         self.kp = kp
+        self._save_callback = save_callback
         self.version_manager = VersionManager()
+
+    def _save(self) -> None:
+        """Save changes via the store callback if available, otherwise directly."""
+        if self._save_callback is not None:
+            self._save_callback()
+        else:
+            self.kp.save()
 
     def _is_simple_secret(self, entry: Entry) -> bool:
         """
@@ -239,7 +247,7 @@ class EntryManager:
         if tags is not None:
             self._set_entry_tags(entry, tags)
 
-        self.kp.save()
+        self._save()
 
         return {
             "name": title,
@@ -270,7 +278,7 @@ class EntryManager:
         if tags is not None:
             self._set_entry_tags(entry, tags)
 
-        self.kp.save()
+        self._save()
 
         return Credential(
             credential_name=title,
@@ -319,7 +327,7 @@ class EntryManager:
         if entry:
             try:
                 self.kp.delete_entry(entry)
-                self.kp.save()
+                self._save()
                 return True
             except Exception as ex:
                 logger.error(f"Failed to delete entry '{title}': {ex}")
@@ -335,7 +343,7 @@ class EntryManager:
         try:
             for entry in versioned:
                 self.kp.delete_entry(entry)
-            self.kp.save()
+            self._save()
             return True
         except Exception as ex:
             logger.error(f"Failed to delete versioned entries for '{title}': {ex}")

--- a/src/mattstash/core/mattstash.py
+++ b/src/mattstash/core/mattstash.py
@@ -61,7 +61,7 @@ class MattStash:
             try:
                 store = CredentialStore(self.path, self.password)
                 kp = store.open()
-                self._entry_manager = EntryManager(kp)
+                self._entry_manager = EntryManager(kp, save_callback=store.save)
                 self._credential_store = store
                 return True
             except Exception as e:
@@ -147,6 +147,42 @@ class MattStash:
             return False
         assert self._entry_manager is not None
         return self._entry_manager.delete_entry(title)
+
+    def reload(self) -> bool:
+        """
+        Reload the KeePass database from disk.
+        Useful when the file has been modified externally (e.g., by the CLI).
+
+        Returns:
+            True if reload was successful, False otherwise.
+        """
+        if self._credential_store is None:
+            # Not yet initialized; just ensure initialization
+            return self._ensure_initialized()
+
+        try:
+            kp = self._credential_store.reload()
+            self._entry_manager = EntryManager(kp, save_callback=self._credential_store.save)
+            logger.info("Database reloaded successfully")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to reload database: {e}")
+            return False
+
+    def reload_if_changed(self) -> bool:
+        """
+        Check if the KDBX file has been modified externally and reload if so.
+
+        Returns:
+            True if a reload was performed, False if no change was detected.
+        """
+        if self._credential_store is None:
+            return False
+
+        if self._credential_store.has_file_changed():
+            logger.info("External database modification detected, reloading")
+            return self.reload()
+        return False
 
     def hydrate_env(self, mapping: Dict[str, str]) -> None:
         """

--- a/src/mattstash/credential_store.py
+++ b/src/mattstash/credential_store.py
@@ -26,6 +26,7 @@ class CredentialStore:
         self.db_path = db_path
         self.password = password
         self._kp: Optional[PyKeePass] = None
+        self._file_mtime: float = 0.0
 
         # Connection caching settings
         self.cache_enabled = cache_enabled or config.cache_enabled
@@ -64,6 +65,10 @@ class CredentialStore:
 
         try:
             self._kp = PyKeePass(self.db_path, password=self.password)
+            try:
+                self._file_mtime = os.path.getmtime(self.db_path)
+            except OSError:
+                self._file_mtime = 0.0
             logger.info("Successfully opened database")
             return self._kp
         except Exception as e:
@@ -164,8 +169,38 @@ class CredentialStore:
         """Save changes to the database and clear cache."""
         if self._kp:
             self._kp.save()
+            try:
+                self._file_mtime = os.path.getmtime(self.db_path)
+            except OSError:
+                self._file_mtime = 0.0
             self.clear_cache()  # Invalidate cache on save
             logger.debug("Database saved successfully")
+
+    def has_file_changed(self) -> bool:
+        """Check if the KDBX file has been modified externally since last open/save.
+
+        Returns:
+            True if the file's mtime differs from the last recorded mtime.
+        """
+        if not os.path.exists(self.db_path):
+            return False
+        current_mtime = os.path.getmtime(self.db_path)
+        return current_mtime != self._file_mtime
+
+    def reload(self) -> Optional[PyKeePass]:
+        """Close and reopen the database from disk.
+
+        Returns:
+            PyKeePass instance after reopening.
+
+        Raises:
+            DatabaseNotFoundError: If database file doesn't exist.
+            DatabaseAccessError: If password is incorrect.
+        """
+        self._kp = None
+        self.clear_cache()
+        logger.info("Reloading database from disk")
+        return self.open()
 
     def delete_entry(self, entry: Entry) -> bool:
         """Delete an entry from the database."""

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -1,0 +1,176 @@
+"""
+Tests for database reload functionality: CredentialStore, MattStash, and server integration.
+"""
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pykeepass import PyKeePass
+
+from mattstash import MattStash
+from mattstash.credential_store import CredentialStore
+
+
+@pytest.fixture()
+def temp_db(tmp_path: Path) -> Path:
+    """Create an isolated directory for each test to hold DB + sidecar."""
+    d = tmp_path / "mattstash"
+    d.mkdir()
+    return d / "test.kdbx"
+
+
+# ---------------------------------------------------------------------------
+# CredentialStore.reload / has_file_changed
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialStoreReload:
+    """Tests for CredentialStore reload and file change detection."""
+
+    def test_has_file_changed_false_after_open(self, temp_db: Path):
+        """After opening, has_file_changed should be False."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+        store = ms._credential_store
+        assert store is not None
+        assert store.has_file_changed() is False
+
+    def test_has_file_changed_true_after_external_write(self, temp_db: Path):
+        """If the file is modified externally, has_file_changed should be True."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+        store = ms._credential_store
+        assert store is not None
+
+        # Simulate external modification by opening kdbx and saving it directly
+        kp = PyKeePass(str(temp_db), password=ms.password)
+        kp.add_entry(kp.root_group, title="ext_entry", username="u", password="p")
+        # Ensure mtime actually changes (filesystem granularity)
+        time.sleep(0.05)
+        kp.save()
+
+        assert store.has_file_changed() is True
+
+    def test_has_file_changed_false_after_save(self, temp_db: Path):
+        """After our own save, has_file_changed should be False."""
+        ms = MattStash(path=str(temp_db))
+        result = ms.put("my-key", value="my-val")
+        assert result is not None
+
+        store = ms._credential_store
+        assert store is not None
+        assert store.has_file_changed() is False
+
+    def test_has_file_changed_nonexistent_db(self):
+        """has_file_changed returns False if the file doesn't exist."""
+        store = CredentialStore("/nonexistent/db.kdbx", "pw")
+        assert store.has_file_changed() is False
+
+    def test_reload_reopens_database(self, temp_db: Path):
+        """reload() should close and reopen the database from disk."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+        store = ms._credential_store
+        assert store is not None
+
+        old_kp = store._kp
+        new_kp = store.reload()
+
+        # Should be a new instance
+        assert new_kp is not old_kp
+        assert new_kp is store._kp
+
+    def test_reload_picks_up_external_entries(self, temp_db: Path):
+        """After an external write, reload should make the new entry visible."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+        store = ms._credential_store
+        assert store is not None
+
+        # External write
+        kp_ext = PyKeePass(str(temp_db), password=ms.password)
+        kp_ext.add_entry(kp_ext.root_group, title="ext_secret", username="", password="external-val")
+        kp_ext.save()
+
+        # Before reload: not visible in the old kp instance
+        old_entry = store._kp.find_entries(title="ext_secret", first=True)
+        assert old_entry is None
+
+        # Reload
+        store.reload()
+
+        # After reload: visible
+        new_entry = store._kp.find_entries(title="ext_secret", first=True)
+        assert new_entry is not None
+        assert new_entry.password == "external-val"
+
+
+# ---------------------------------------------------------------------------
+# MattStash.reload / reload_if_changed
+# ---------------------------------------------------------------------------
+
+
+class TestMattStashReload:
+    """Tests for MattStash reload and reload_if_changed."""
+
+    def test_reload_returns_true(self, temp_db: Path):
+        """reload() should return True on success."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+        assert ms.reload() is True
+
+    def test_reload_before_init(self, temp_db: Path):
+        """reload() before initialization should perform init."""
+        ms = MattStash(path=str(temp_db))
+        # Not yet initialized
+        assert ms._credential_store is None
+        result = ms.reload()
+        assert result is True
+        assert ms._credential_store is not None
+
+    def test_reload_if_changed_no_change(self, temp_db: Path):
+        """reload_if_changed returns False when nothing changed."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+        assert ms.reload_if_changed() is False
+
+    def test_reload_if_changed_after_external_write(self, temp_db: Path):
+        """reload_if_changed returns True and reloads after external change."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+
+        # External write
+        kp_ext = PyKeePass(str(temp_db), password=ms.password)
+        kp_ext.add_entry(kp_ext.root_group, title="ext_val", username="", password="xyz")
+        time.sleep(0.05)
+        kp_ext.save()
+
+        assert ms.reload_if_changed() is True
+
+        # Verify the entry is now visible
+        result = ms.get("ext_val", show_password=True)
+        assert result is not None
+
+    def test_reload_if_changed_not_initialized(self, temp_db: Path):
+        """reload_if_changed returns False when not initialized."""
+        ms = MattStash(path=str(temp_db))
+        assert ms.reload_if_changed() is False
+
+    def test_reload_recreates_entry_manager(self, temp_db: Path):
+        """reload() should create a new EntryManager with the new kp."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+        old_em = ms._entry_manager
+
+        ms.reload()
+        assert ms._entry_manager is not old_em
+
+    def test_reload_failure_returns_false(self, temp_db: Path):
+        """reload() returns False when the reload raises an error."""
+        ms = MattStash(path=str(temp_db))
+        ms._ensure_initialized()
+
+        with patch.object(ms._credential_store, "reload", side_effect=Exception("disk error")):
+            assert ms.reload() is False


### PR DESCRIPTION
## Summary

Adds file change detection and reload capability so the server automatically picks up credentials written directly to the KDBX file by the CLI or other external tools.

## Problem

The server loads the KDBX into a singleton \`PyKeePass\` instance at startup. Credentials written via the CLI (which opens/saves the file directly) were invisible to the running server because its in-memory state was never refreshed.

## Solution

### Library layer (\`src/mattstash/\`)
- **\`CredentialStore\`** — tracks file mtime; adds \`has_file_changed()\` and \`reload()\`
- **\`EntryManager\`** — routes all saves through \`CredentialStore.save()\` via callback so mtime is always updated after our own writes
- **\`MattStash\`** — adds \`reload()\` (force) and \`reload_if_changed()\` (conditional) public methods

### Server layer (\`server/app/\`)
- **Background poller** in the lifespan checks file mtime every \`MATTSTASH_DB_POLL_INTERVAL\` seconds (default 5, set 0 to disable) and auto-reloads on change
- **\`POST /api/v1/admin/reload\`** endpoint for explicit forced reload (requires API key)
- New env var: \`MATTSTASH_DB_POLL_INTERVAL\`

## Tests
- 13 new tests for \`CredentialStore\`/\`MattStash\` reload functionality
- 7 new tests for server admin endpoint and dependency functions
- All 222 app tests pass, all 57 server tests pass (91.87% coverage)
- Linting clean